### PR TITLE
Fix dnsmasq, remove redundant.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -639,9 +639,6 @@ if [[ `grep -c "net.netfilter.nf_conntrack_max" ${HOME_PATH}/package/kernel/linu
 else
   sed -i 's/net.netfilter.nf_conntrack_max=.*/net.netfilter.nf_conntrack_max=165535/g' ${HOME_PATH}/package/kernel/linux/files/sysctl-nf-conntrack.conf
 fi
-if [[ `grep -c "min-cache-ttl=" ${HOME_PATH}/package/network/services/dnsmasq/files/dnsmasq.conf` -eq '0' ]]; then
-  echo -e "#max-ttl=600\nneg-ttl=600\nmin-cache-ttl=3600" >> ${HOME_PATH}/package/network/services/dnsmasq/files/dnsmasq.conf
-fi
 
 source ${HOME_PATH}/build/common/Share/19.07/netsupport.sh
 


### PR DESCRIPTION
Adding these to dnsmasq.conf will lead to dnsmasq crash since auto-gen file with default setting already include these
This is catastrophic as it will cause the factory set Immoralwrt's dnsmasq startup to fail resulting in unable to assign IPV4 address

> Thu Feb 29 19:31:34 2024 daemon.crit dnsmasq[1]: FAILED to start up
> Thu Feb 29 19:31:39 2024 daemon.crit dnsmasq[1]: illegal repeated keyword at line 15 of /var/etc/dnsmasq.conf.cfg01411c
> Thu Feb 29 19:31:39 2024 daemon.crit dnsmasq[1]: FAILED to start up
> Thu Feb 29 19:31:44 2024 daemon.crit dnsmasq[1]: illegal repeated keyword at line 15 of /var/etc/dnsmasq.conf.cfg01411c
> Thu Feb 29 19:31:44 2024 daemon.crit dnsmasq[1]: FAILED to start up
> Thu Feb 29 19:31:49 2024 daemon.crit dnsmasq[1]: illegal repeated keyword at line 15 of /var/etc/dnsmasq.conf.cfg01411c
> Thu Feb 29 19:31:49 2024 daemon.crit dnsmasq[1]: FAILED to start up
> Thu Feb 29 19:31:54 2024 daemon.crit dnsmasq[1]: illegal repeated keyword at line 15 of /var/etc/dnsmasq.conf.cfg01411c
> Thu Feb 29 19:31:54 2024 daemon.crit dnsmasq[1]: FAILED to start up
> Thu Feb 29 19:31:59 2024 daemon.crit dnsmasq[1]: illegal repeated keyword at line 15 of /var/etc/dnsmasq.conf.cfg01411c
> Thu Feb 29 19:31:59 2024 daemon.crit dnsmasq[1]: FAILED to start up
> Thu Feb 29 19:31:59 2024 daemon.info procd: Instance dnsmasq::cfg01411c s in a crash loop 6 crashes, 0 seconds since last crash

